### PR TITLE
[DEN-285] Rules Engine Policy: Ignore Name During Comparison

### DIFF
--- a/edgecast/resources/rulesengine/v4policy.go
+++ b/edgecast/resources/rulesengine/v4policy.go
@@ -439,7 +439,9 @@ func policyDiffSuppress(k, old, new string, _ *schema.ResourceData) bool {
 	_ = json.Unmarshal([]byte(old), &oldPolicy)
 	_ = json.Unmarshal([]byte(new), &newPolicy)
 
-	oldPolicy["name"], newPolicy["name"] = "", "" // ignore name changes
+	// ignore name changes
+	delete(oldPolicy, "name")
+	delete(newPolicy, "name")
 
 	return reflect.DeepEqual(oldPolicy, newPolicy) == false
 }

--- a/edgecast/resources/rulesengine/v4policy_test.go
+++ b/edgecast/resources/rulesengine/v4policy_test.go
@@ -1,0 +1,106 @@
+package rulesengine
+
+import (
+	"encoding/json"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"testing"
+)
+
+type JSONMap map[string]any
+
+func (j JSONMap) String() string {
+	b, err := json.Marshal(j)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func Test_policyDiffSuppress(t *testing.T) {
+	source := JSONMap{
+		"name": "a",
+		"a":    "b",
+		"c":    "d",
+	}
+	diffNameShouldMatch := JSONMap{
+		"name": "b",
+		"a":    "b",
+		"c":    "d",
+	}
+	diffNameShouldFail := JSONMap{
+		"name": "b",
+		"a":    "x",
+		"c":    "x",
+	}
+	sameNameShouldMatch := JSONMap{
+		"name": "a",
+		"a":    "b",
+		"c":    "d",
+	}
+	sameNameShouldFail := JSONMap{
+		"name": "a",
+		"a":    "x",
+		"c":    "x",
+	}
+
+	type args struct {
+		k   string
+		old string
+		new string
+		in3 *schema.ResourceData
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Different Name Should Match",
+			args: args{
+				k:   "",
+				old: source.String(),
+				new: diffNameShouldMatch.String(),
+				in3: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Different Name Should Fail",
+			args: args{
+				k:   "",
+				old: source.String(),
+				new: diffNameShouldFail.String(),
+				in3: nil,
+			},
+			want: true,
+		},
+
+		{
+			name: "Same Name Should Match",
+			args: args{
+				k:   "",
+				old: source.String(),
+				new: sameNameShouldMatch.String(),
+				in3: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Different Name Should Fail",
+			args: args{
+				k:   "",
+				old: source.String(),
+				new: sameNameShouldFail.String(),
+				in3: nil,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policyDiffSuppress(tt.args.k, tt.args.old, tt.args.new, tt.args.in3); got != tt.want {
+				t.Errorf("policyDiffSuppress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/integration/Integration.Taskfile.yaml
+++ b/test/integration/Integration.Taskfile.yaml
@@ -6,10 +6,12 @@ silent: true
 
 tasks:
   default:
+    vars:
+      CLEANUP_FILES: resource.tf .terraform .terraform.* terraform.tfstate*
     cmds:
-      - defer: rm -rf resource.tf .terraform .terraform.*
+      - defer: rm -rf {{.CLEANUP_FILES}}
       - defer: terraform apply -auto-approve -destroy {{.CREDS}} {{.ACCOUNT}}
-      - rm -rf resource.tf .terraform .terraform.*
+      - rm -rf {{.CLEANUP_FILES}}
       - terraform init
       - cp create.tf.step resource.tf
       - terraform validate


### PR DESCRIPTION
# What's New?
- Included a `DiffSuppressFunc` for `policy` within `ResourceRulesEngineV4Policy`, this will ignore the `name` key of the policy when comparing for changes.
- Optimized the cleanup of files within `Integration.TaskFile.yml`.

# Testing
- Included unit tests ensuring expected functionality.